### PR TITLE
Add dashboard page route and function to displayed upcoming appointments

### DIFF
--- a/app/templates/page_4_DashboardPage.html
+++ b/app/templates/page_4_DashboardPage.html
@@ -16,52 +16,18 @@
             <div class="text-center col-md-12 upcoming-appt-col">
                 <h2 class="h2-title mb-4">Your Upcoming Appointments</h2>
                 <div class="d-grid gap-3">
-
+                    {% for appt in upcoming_appointments %}
                     <div class="p-3 bg-light rounded shadow-sm upcoming-appt-details">
                         <div class="row align-items-center">
-                            <div class="col-md-3 fw-bold">2 Days Away →</div>
-                            <div class="col-md-3">Apr 28th</div>
-                            <div class="col-md-4">Dr. Lim (Physiotherapy)</div>
-                            <div class="col-md-2">10:00am</div>
+                            <div class="col-md-3 fw-bold">{{ appt.days_away }} Days Away →</div>
+                            <div class="col-md-2">{{ appt.date }}</div>
+                            <div class="col-md-4">{{ appt.practitioner }} ({{ appt.type }})</div>
+                            <div class="col-md-3">{{ appt.start_time }} - {{ appt.end_time }}</div>
                         </div>
                     </div>
-
-                    <div class="p-3 bg-light rounded shadow-sm upcoming-appt-details">
-                        <div class="row align-items-center">
-                            <div class="col-md-3 fw-bold">5 Days Away →</div>
-                            <div class="col-md-3">May 1st</div>
-                            <div class="col-md-4">Dr. Tan (Cardiology)</div>
-                            <div class="col-md-2">1:30pm</div>
-                        </div>
-                    </div>
-
-                    <div class="p-3 bg-light rounded shadow-sm upcoming-appt-details">
-                        <div class="row align-items-center">
-                            <div class="col-md-3 fw-bold">7 Days Away →</div>
-                            <div class="col-md-3">May 3rd</div>
-                            <div class="col-md-4">Dr. Wong (Orthopedics)</div>
-                            <div class="col-md-2">11:00am</div>
-                        </div>
-                    </div>
-
-                    <div class="p-3 bg-light rounded shadow-sm upcoming-appt-details">
-                        <div class="row align-items-center">
-                            <div class="col-md-3 fw-bold">10 Days Away →</div>
-                            <div class="col-md-3">May 6th</div>
-                            <div class="col-md-4">Dr. Smith (Dentist)</div>
-                            <div class="col-md-2">9:00am</div>
-                        </div>
-                    </div>
-
-                    <div class="p-3 bg-light rounded shadow-sm upcoming-appt-details">
-                        <div class="row align-items-center">
-                            <div class="col-md-3 fw-bold">12 Days Away →</div>
-                            <div class="col-md-3">May 8th</div>
-                            <div class="col-md-4">Dr. Chua (General)</div>
-                            <div class="col-md-2">4:00pm</div>
-                        </div>
-                    </div>
-
+                    {% else %}
+                    <p class="text-muted">No upcoming appointments.</p>
+                    {% endfor %}
                 </div>
             </div>
         </div>


### PR DESCRIPTION
- Modified the /dashboard route to return only the next 5 upcoming appointments for the logged-in member. Appointments are now sorted by date and displayed with formatted times and days remaining.
- Updated the dashboard page layout to clearly present up to 5 earliest upcoming appointments. Each appointment now shows days away, date, practitioner name/type, and start-end time. It included fallback message if no appointments exist.