### PR TITLE
Sort notifications by most recent triggered/ notified date

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -212,6 +212,8 @@ def inject_notifications():
 
         n_not = len(notifications)  # badge will now show ALL relevant notifications
 
+    notifications.sort(key=lambda x: x.get("triggered_on"), reverse=True)
+
     return dict(n_not=n_not, notifications=notifications)
 
 # Page 5 - Appointments Manager Page


### PR DESCRIPTION
- Updated inject_notifications in routes.py to sort the notifications list by the most recent 'triggered_on' timestamp in descending order. This ensures that the latest reminders appear at the top of the notification dropdown for improved visibility.